### PR TITLE
Add Continuous Integration badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://semaphoreci.com/api/v1/diproche/webinterface/branches/master/badge.svg)](https://semaphoreci.com/diproche/webinterface)
+
 # Diproche-Webinterface
 
 ## Developing


### PR DESCRIPTION
Adds a badge to our readme that shows the live-status of the CI-status of our master-branch.