### PR TITLE
Add variable errorHere to line with error

### DIFF
--- a/src/components/proofEditor/proofEditor.tsx
+++ b/src/components/proofEditor/proofEditor.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { checkProof } from "../../util/proofChecker";
 import styles from "./proofEditor.module.scss";
 
+// tslint:disable-next-line:no-empty-interface
 export interface Props {
 	errorHere: string;
 }

--- a/src/components/proofEditor/proofEditor.tsx
+++ b/src/components/proofEditor/proofEditor.tsx
@@ -3,7 +3,7 @@ import { checkProof } from "../../util/proofChecker";
 import styles from "./proofEditor.module.scss";
 
 export interface Props {
-
+	errorHere: string;
 }
 
 interface State {

--- a/src/components/proofEditor/proofEditor.tsx
+++ b/src/components/proofEditor/proofEditor.tsx
@@ -4,7 +4,6 @@ import styles from "./proofEditor.module.scss";
 
 // tslint:disable-next-line:no-empty-interface
 export interface Props {
-	errorHere: string;
 }
 
 interface State {

--- a/src/util/diproche/diprocheInterface.test.ts
+++ b/src/util/diproche/diprocheInterface.test.ts
@@ -1,5 +1,3 @@
-import { Severity } from "../../checking/issue";
-import { IssueCode } from "../../checking/issueCodes";
 import { getAllIssues } from "../../vocabularyChecker/detectWrongSyntax";
 import getErrors from "./diprocheInterface";
 import {addPredicate, getVocabErrors, Mode} from "./diprocheInterface";

--- a/src/util/diproche/diprocheInterface.ts
+++ b/src/util/diproche/diprocheInterface.ts
@@ -1,5 +1,5 @@
-import IssueCode from "../../checking/issueCodes";
 import {ProofEditor} from "../../components/proofEditor/proofEditor";
+import {addIssue, addIssueToIssueList, concatOneIssueList} from "../../issueHandling/issueMapping";
 import { getAllIssues } from "../../vocabularyChecker/detectWrongSyntax";
 import { UnexpectedError } from "./Errors";
 import modes from "./predicateList.json";

--- a/src/vocabularyChecker/detectWrongSyntax.test.ts
+++ b/src/vocabularyChecker/detectWrongSyntax.test.ts
@@ -5,7 +5,6 @@ import { collectAllInvalidWords, collectInvalidWordsInIssues, getAllIssues } fro
 import { getInvalidWords, logMultipleOccurences, logMultipleWords, logSingleWord } from "./detectWrongSyntax";
 import { Position } from "./detectWrongSyntax";
 
-
 describe("getInvalidWords", () => {
 	it("Returns the correct word for a normal text", () => {
 		const wrongWords = getInvalidWords("fu bar bloedsinn"); // fu and bar are indeed included in allowedVocab


### PR DESCRIPTION
The problem right now is, if you delete the "errorHere" variable from the Props-interface, you get a lintererror, since no empty interfaces are allowed. How should we handle this?