### PR TITLE
TimothyGillespie/integratingSWIServer

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
 		"@types/react-dom": "16.8.3",
 		"shx": "^0.3.2",
 		"tslint": "^5.17.0"
-	}
+	},
+	"proxy" : "http://localhost:5000" 
 }

--- a/src/components/proofEditor/issueInformation.tsx
+++ b/src/components/proofEditor/issueInformation.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Issue from "../../issueHandling/issue";
 import IssuePositionInformation from "./issuePositionInformation";
+
 import styles from "./proofEditor.module.scss";
 
 export interface Props {

--- a/src/components/proofEditor/proofEditor.tsx
+++ b/src/components/proofEditor/proofEditor.tsx
@@ -44,8 +44,8 @@ export class ProofEditor extends React.Component<Props, State> {
 
 	}
 
-	private readonly checkInput = (): void => {
-		const issueArray: readonly Issue[] = checkProof(this.state.userInput);
+	private readonly checkInput = async (): Promise<void> => {
+		const issueArray: readonly Issue[] = await checkProof(this.state.userInput);
 		this.setState({issues:  issueArray});
 	}
 }

--- a/src/issueHandling/knownIssues.json
+++ b/src/issueHandling/knownIssues.json
@@ -26,5 +26,9 @@
 	"INVALID_WORD": {
 		"severity": "WARNING",
 		"message": "Das Wort '{word}' in der Eingabe ist nicht erlaubt."
+	},
+	"UNVERIFIED_LINE": {
+		"severity": "HINT",
+		"message": "Eine Zeile konnte nicht verfiziert werden."
 	}
 }

--- a/src/util/diproche/diprocheResponseProcessing.ts
+++ b/src/util/diproche/diprocheResponseProcessing.ts
@@ -1,0 +1,49 @@
+import * as _ from "lodash";
+import {addIssue} from "../../issueHandling/issueMapping";
+
+export function addDiprocheIssues(diprocheResponse: string): void {
+	const errorList = convertErrorListStringToJSArray(getErrorList(diprocheResponse));
+	errorList[0].forEach((unverifiedLine: number) => {
+		addIssue("UNVERIFIED_LINE", {
+			fromIndex: unverifiedLine,
+			toIndex: unverifiedLine,
+		});
+	});
+}
+
+function convertErrorListStringToJSArray(listAsString: string): number[][] {
+	let stringCopy: string = listAsString;
+
+	// Removing the outter brackets
+	stringCopy = stringCopy.slice(1);
+	stringCopy = stringCopy.slice(0, stringCopy.length - 1);
+
+	const outterForm: string[] = stringCopy.split(",");
+	const jsArray: number[][] = [];
+
+	outterForm.forEach((innerString: string) => {
+		innerString = innerString.slice(1);
+		innerString = innerString.slice(0, innerString.length - 1);
+
+		const innerArray: string[] | undefined = innerString.split(",");
+
+		if ( !innerArray || _.isEqual(innerArray, new Array("")) ) {
+			jsArray.push(new Array());
+		} else {
+			innerArray.forEach((element: string) => jsArray.push([parseInt(element, 10)]));
+		}
+	});
+
+	return jsArray;
+}
+
+function getErrorList(diprocheResponse: string): string {
+	const fetchErrorListRegExp = /List of Lists with unverified Input: ([^$]*)/;
+	const ErrorList: RegExpExecArray | null = fetchErrorListRegExp.exec(diprocheResponse);
+ if (ErrorList) {
+	return ErrorList[1];
+ }
+
+ throw new Error("No error list found in the reponse from diproche.");
+
+}

--- a/src/util/proofChecker.ts
+++ b/src/util/proofChecker.ts
@@ -1,5 +1,4 @@
 import Issue from "../issueHandling/issue";
-import {addIssue} from "../issueHandling/issueMapping";
 import {listAllIssues} from "../issueHandling/issueMapping";
 import {addDiprocheIssues} from "../util/diproche/diprocheResponseProcessing";
 
@@ -14,8 +13,6 @@ const severities: string[] = ["FATALERROR", "ERROR", "WARNING", "HINT"];
 export async function checkProof(userInput: string): Promise<readonly Issue[]> {
 
 	// runPipeline(userinput); (or whatever will run the userinput through the checks)
-	addIssue("BRACKET_OVERCLOSING");
-	addIssue("BRACKET_UNDERCLOSING", { fromIndex: 24, toIndex: 29});
 
 	addDiprocheIssues( await getDiprocheResponse(userInput) );
 

--- a/src/util/proofChecker.ts
+++ b/src/util/proofChecker.ts
@@ -1,6 +1,7 @@
 import Issue from "../issueHandling/issue";
 import {addIssue} from "../issueHandling/issueMapping";
 import {listAllIssues} from "../issueHandling/issueMapping";
+import {addDiprocheIssues} from "../util/diproche/diprocheResponseProcessing";
 
 // Ordered by their degree of fatality
 const severities: string[] = ["FATALERROR", "ERROR", "WARNING", "HINT"];
@@ -10,13 +11,32 @@ const severities: string[] = ["FATALERROR", "ERROR", "WARNING", "HINT"];
 	* @param {string} userInput - The user input
 	* @return {Array<Issue>} The syntatical, sementatical and technical issues for the given user input
 	*/
-export function checkProof(userInput: string): readonly Issue[] {
+export async function checkProof(userInput: string): Promise<readonly Issue[]> {
 
 	// runPipeline(userinput); (or whatever will run the userinput through the checks)
-	userInput = userInput;
 	addIssue("BRACKET_OVERCLOSING");
 	addIssue("BRACKET_UNDERCLOSING", { fromIndex: 24, toIndex: 29});
+
+	addDiprocheIssues( await getDiprocheResponse(userInput) );
+
 	return orderIssuesBySeverity(listAllIssues());
+}
+
+async function getDiprocheResponse(userInput: string): Promise<string> {
+
+	const body = userInput;
+
+	const response = await fetch("http://localhost:3000/dipr", {
+		headers: {
+			"Content-Type": "application/x-prolog",
+		},
+		method: "POST",
+		body,
+	});
+
+	const responseText = await response.text();
+	console.log(responseText);
+	return responseText;
 }
 
 /**


### PR DESCRIPTION
This will integrate diproche issue recognition.

Usage:
Run the SWIServer on port 5000

1. Find the hello.pl file.
2. Put the current diproche program into the same folder.
3. Open the hello.pl file.
4. Type in: `server(5000).`
5. Leave it open while using the webinterface.

Currently the textfield doesn't convert from normal text to the list format. This needed to put in there.
The proxy setting in the package.json is used to circumvent CORS issue. Though this can be implemented later so it can be done without the proxy. For this see:

Prolog: https://www.swi-prolog.org/pldoc/man?section=httpcors
Javascript/Typescipt: https://www.html5rocks.com/en/tutorials/cors/

The circumvented issue in question: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMissingAllowOrigin
