### PR TITLE
Fix indexing error

### DIFF
--- a/src/util/vocabularyChecker/detectWrongSyntax.test.ts
+++ b/src/util/vocabularyChecker/detectWrongSyntax.test.ts
@@ -125,10 +125,11 @@ describe("CollectAllInvalidWordsInIssues", () => {
 		]);
 	});
 
-	it("Creates a correct Issue-array for a word consisting only of a Whitespace", () => {
+	it("Empties the issue-list correctly", () => {
 		emptyIssueList();
 		expect(listAllIssues()).toEqual([]);
 	});
+
 	it("Creates a correct Issue-array for two copies of the same wrong word", () => {
 		collectInvalidWordsInIssues("Sonne und Sonne");
 		expect(listAllIssues()).toEqual([

--- a/src/util/vocabularyChecker/detectWrongSyntax.test.ts
+++ b/src/util/vocabularyChecker/detectWrongSyntax.test.ts
@@ -129,4 +129,51 @@ describe("CollectAllInvalidWordsInIssues", () => {
 		emptyIssueList();
 		expect(listAllIssues()).toEqual([]);
 	});
+	it("Creates a correct Issue-array for two copies of the same wrong word", () => {
+		collectInvalidWordsInIssues("Sonne und Sonne");
+		expect(listAllIssues()).toEqual([
+			{
+				code: "INVALID_WORD",
+				message: "Das Wort 'Sonne' in der Eingabe ist nicht erlaubt.",
+				position: {
+					fromIndex: 0,
+					toIndex: 5,
+				},
+				severity: issueJson.INVALID_WORD.severity,
+			},
+			{
+				code: "INVALID_WORD",
+				message: "Das Wort 'Sonne' in der Eingabe ist nicht erlaubt.",
+				position: {
+					fromIndex: 10,
+					toIndex: 15,
+				},
+				severity: issueJson.INVALID_WORD.severity,
+			},
+		]);
+		emptyIssueList();
+	});
+	it("Does not create unneccessary issues when a wrong word is a substring of another wrong word", () => {
+		collectInvalidWordsInIssues("ff ffff");
+		expect(listAllIssues()).toEqual([
+			{
+				code: "INVALID_WORD",
+				message: "Das Wort 'ff' in der Eingabe ist nicht erlaubt.",
+				position: {
+					fromIndex: 0,
+					toIndex: 2,
+				},
+				severity: issueJson.INVALID_WORD.severity,
+			},
+			{
+				code: "INVALID_WORD",
+				message: "Das Wort 'ffff' in der Eingabe ist nicht erlaubt.",
+				position: {
+					fromIndex: 3,
+					toIndex: 7,
+				},
+				severity: issueJson.INVALID_WORD.severity,
+			},
+		]);
+	});
 });

--- a/src/util/vocabularyChecker/detectWrongSyntax.ts
+++ b/src/util/vocabularyChecker/detectWrongSyntax.ts
@@ -2,7 +2,7 @@ import Issue from "../issueHandling/issue";
 import { addIssue } from "../issueHandling/issueMapping";
 import issueJson from "../issueHandling/knownIssues.json";
 import json from "./allowedVocab.json";
-import uniqueValues from "./iterators";
+import uniqueValues from "./Iterators";
 
 /**
  * Regular expression that looks for any and all words. A word is defined as some sequence of

--- a/src/util/vocabularyChecker/detectWrongSyntax.ts
+++ b/src/util/vocabularyChecker/detectWrongSyntax.ts
@@ -2,7 +2,7 @@ import Issue from "../issueHandling/issue";
 import { addIssue } from "../issueHandling/issueMapping";
 import issueJson from "../issueHandling/knownIssues.json";
 import json from "./allowedVocab.json";
-import uniqueValues from "./Iterators";
+import uniqueValues from "./iterators";
 
 /**
  * Regular expression that looks for any and all words. A word is defined as some sequence of
@@ -15,10 +15,14 @@ export const anyWord = new RegExp(/\b\w+\b/g);
 const allowedWords = json;
 export interface Position { fromIndex: number; toIndex: number; }
 
-export function collectInvalidWordsInIssues(text: string) {
+/**
+ * Adds an Issue for every invalid word.
+ * @param text the userinput
+ */
+export function collectInvalidWordsInIssues(text: string): void {
 	const invalidWords = getInvalidWords(text);
 	for (const word of invalidWords) {
-		if (!(allowedWords.includes(word.toLowerCase()))) {
+		if ((!(allowedWords.includes(word.toLowerCase())))) {
 			const allPositionsOfInvalidWord = getPositionsOfInvalidWord(word, text);
 			for (const pos of allPositionsOfInvalidWord) {
 				addIssue("INVALID_WORD", pos, {word});
@@ -27,12 +31,18 @@ export function collectInvalidWordsInIssues(text: string) {
 	}
 }
 
-export function getPositionsOfInvalidWord(invalidWord: string, text: string): Position[] {
+/**
+ * Creates a Array of each occurence of a given word in a text.
+ * @param invalidWord - A word that is not listed in allowedVocab.json
+ * @param text - the userinput
+ */
+function getPositionsOfInvalidWord(invalidWord: string, text: string): Position[] {
 	const result: Position[] = [];
 	let offSet: number = 0;
 
 	let foundIndex: number;
-	while ((foundIndex = text.indexOf(invalidWord, offSet)) !== -1) {
+	text = " " + text + " ";
+	while ((foundIndex = text.indexOf(" " + invalidWord + " ", offSet)) !== -1) {
 	console.log(foundIndex);
 	offSet = foundIndex + 1;
 	result.push({
@@ -44,8 +54,7 @@ export function getPositionsOfInvalidWord(invalidWord: string, text: string): Po
 }
 
 /**
- * Bundling the functionalities of @function collectAllInvalidWords and
- * @function removeDuplicates.
+ * Bundling the functionalities of @function collectAllInvalidWords and @function removeDuplicates.
  * @returns a Stringarray containing exactly one copy of each wrong word in a text.
  */
 export function getInvalidWords(text: string): string[] {
@@ -53,9 +62,10 @@ export function getInvalidWords(text: string): string[] {
 }
 
 /**
- * @returns a Stringarray containing every occurrence of each wrong word in a text.
+ * Collects all words that are invalid.
+ * @param text - the userinput
  */
-export function collectAllInvalidWords(text: string): string[] {
+function collectAllInvalidWords(text: string): string[] {
 	const words = text.match(anyWord) || [];
 	return words.filter(word => !(allowedWords.includes(word.toLowerCase())));
 }
@@ -72,10 +82,15 @@ export function logMultipleWords(words: string[], positions: Position[]): Issue[
 	return words.map(word => logMultipleOccurences(word, positions));
 }
 
-export function logMultipleOccurences(word: string, position: Position[]): Issue[] {
+function logMultipleOccurences(word: string, position: Position[]): Issue[] {
 	return position.map(pos => logSingleWord(word, pos));
 }
 
+/**
+ * Creates an Issue of one word.
+ * @param word - a word that is invalid
+ * @param position - the position of the word
+ */
 export function logSingleWord(word: string, position: Position): Issue {
 	return {
 		message: `${word} von Stelle ${position.fromIndex} bis ${position.toIndex} ist ein unerlaubtes Wort! \n`,

--- a/src/util/vocabularyChecker/detectWrongSyntax.ts
+++ b/src/util/vocabularyChecker/detectWrongSyntax.ts
@@ -17,12 +17,12 @@ export interface Position { fromIndex: number; toIndex: number; }
 
 /**
  * Adds an Issue for every invalid word.
- * @param text the userinput
+ * @param text the user-input
  */
 export function collectInvalidWordsInIssues(text: string): void {
 	const invalidWords = getInvalidWords(text);
 	for (const word of invalidWords) {
-		if ((!(allowedWords.includes(word.toLowerCase())))) {
+		if (!(allowedWords.includes(word.toLowerCase()))) {
 			const allPositionsOfInvalidWord = getPositionsOfInvalidWord(word, text);
 			for (const pos of allPositionsOfInvalidWord) {
 				addIssue("INVALID_WORD", pos, {word});

--- a/src/util/vocabularyChecker/detectWrongSyntax.ts
+++ b/src/util/vocabularyChecker/detectWrongSyntax.ts
@@ -54,7 +54,7 @@ function getPositionsOfInvalidWord(invalidWord: string, text: string): Position[
 }
 
 /**
- * Bundling the functionalities of @function collectAllInvalidWords and @function removeDuplicates.
+ * Bundling the functionalities of collectAllInvalidWords and removeDuplicates.
  * @returns a Stringarray containing exactly one copy of each wrong word in a text.
  */
 export function getInvalidWords(text: string): string[] {


### PR DESCRIPTION
This should fix #50.

The issue was, that an input like "ff ffff" spat out four issues when only two shoul be created.

The reason of this was, that "ff" was detected as an invalid word and the whole input was searched for additional occurences of "ff". 

The solution I implemented was: A word is classified as some sequence of characters between whitespaces. Therefore I now take the user input and append a Whitespace in the front and back of it and only look for occurences of " ff ", i.e. occurences of "ff" that have a whitespace in the front and back now. This solution is a bit hacky, but it should be justified, since it builds upon the definition of a word.