### PR TITLE
Fix the issue of not showing Diproche issues

### DIFF
--- a/src/util/proofChecker.ts
+++ b/src/util/proofChecker.ts
@@ -12,7 +12,7 @@ const severities: string[] = ["FATALERROR", "ERROR", "WARNING", "HINT"];
 	*/
 export async function checkProof(userInput: string): Promise<readonly Issue[]> {
 	emptyIssueList();
-	createErrors(userInput);
+	await createErrors(userInput);
 	return orderIssuesBySeverity(listAllIssues());
 }
 


### PR DESCRIPTION
An await keyword was missing which has now been added. The asynchronity created the issue too late.
Resolves issue #88 