### PR TITLE
Convert \n to a white space in the input check

### DIFF
--- a/src/util/proofChecker.ts
+++ b/src/util/proofChecker.ts
@@ -12,7 +12,8 @@ const severities: string[] = ["FATALERROR", "ERROR", "WARNING", "HINT"];
 	*/
 export async function checkProof(userInput: string): Promise<readonly Issue[]> {
 	emptyIssueList();
-	await createErrors(userInput);
+	const curatedUserInput: string = userInput.replace("\n", " ");
+	await createErrors(curatedUserInput);
 	return orderIssuesBySeverity(listAllIssues());
 }
 


### PR DESCRIPTION
This will solve #104 since the vocab checker doesn't have the issue with a single line input. There is no need to preserve \n (new line) characters as of now.