### PR TITLE
Create an asynchronous wrapper around the swipl-wasm-interface

### DIFF
--- a/src/util/prolog/fubar.test.ts
+++ b/src/util/prolog/fubar.test.ts
@@ -1,14 +1,59 @@
 import "../../../swipl-wasm/swipl-web";
-import { loadingFinishedPromise, query } from "./fubar";
+import { consult, query } from "./fubar";
 
 describe("Fubar", () => {
-	test("Tests bob is a man", async () => {
-		await loadingFinishedPromise;
-		query("man(bob).");
+	test("Test whether bob and frank are men", async () => {
+		await consult("man(bob).");
+		expect(await query("man(bob).")).toEqual(["true."]);
+		expect(await query("man(frank).")).toEqual(["false."]);
 	});
 
-	test("Tests frank is not a man", async () => {
-		await loadingFinishedPromise;
-		query("man(frank).");
+	test("Waiting on previous results and maintaining order is not necessary", async () => {
+		consult("man(bob).");
+		const bobResult = query("man(bob).");
+		const frankResult = query("man(frank).");
+
+		expect(await frankResult).toEqual(["false."]);
+		expect(await bobResult).toEqual(["true."]);
 	});
+
+	test("Can reconsult", async () => {
+		consult("man(bob).");
+		const bobResult = query("man(bob).");
+
+		consult("man(frank).");
+		const frankResult = query("man(frank).");
+
+		expect(await bobResult).toEqual(["true."]);
+		expect(await frankResult).toEqual(["true."]);
+	});
+
+	test("Can return concrete answer", async () => {
+		await consult("man(bob).");
+		expect(await query("man(N).")).toEqual(["N = bob."]);
+	});
+
+	/* doesn't work yet.
+
+	test("Can return multiple answers", async () => {
+		await consult("man(bob). man(frank).");
+		expect(await query("man(N).")).toEqual(["N = bob;", "N = frank."]);
+	});
+
+	test("Handles consulting errors", async () => {
+		try {
+			await consult("man(bob.");
+			fail("Should have thrown.");
+		} catch (e) {
+			expect(e.message).toBe(
+				"ERROR: /file.pl:1:7: Syntax error: Operator expected",
+			);
+		}
+	});
+
+	test("Handles querying errors", async () => {
+		await consult("man(bob).");
+		await query("man(bob).");
+	});
+	*/
 });

--- a/src/util/prolog/fubar.test.ts
+++ b/src/util/prolog/fubar.test.ts
@@ -1,7 +1,11 @@
 import "../../../swipl-wasm/swipl-web";
-import { consult, query } from "./fubar";
+import { consult, loadingComplete as swiLoadingComplete, query } from "./fubar";
 
 describe("Fubar", () => {
+	beforeAll(async () => {
+		await swiLoadingComplete;
+	}, 15000);
+
 	test("Test whether bob and frank are men", async () => {
 		await consult("man(bob).");
 		expect(await query("man(bob).")).toEqual(["true."]);

--- a/src/util/prolog/fubar.ts
+++ b/src/util/prolog/fubar.ts
@@ -57,6 +57,7 @@ export function consult(program: string): Promise<void> {
 }
 
 let loadingFinished!: () => void;
+/** An awaitable promise to make sure SWI is loaded and responsive. */
 export const loadingComplete = new Promise<void>(resolve => {
 	loadingFinished = () => resolve();
 });

--- a/src/util/prolog/fubar.ts
+++ b/src/util/prolog/fubar.ts
@@ -57,11 +57,12 @@ export function consult(program: string): Promise<void> {
 }
 
 let loadingFinished!: () => void;
-let printListener: ((str: string) => void) | undefined;
-let errorListener: ((str: string) => void) | undefined;
-let lastPromise: Promise<unknown> = new Promise<void>(resolve => {
+export const loadingComplete = new Promise<void>(resolve => {
 	loadingFinished = () => resolve();
 });
+let printListener: ((str: string) => void) | undefined;
+let errorListener: ((str: string) => void) | undefined;
+let lastPromise: Promise<unknown> = loadingComplete;
 
 let bindings: any = null;
 let stdin = "";

--- a/tslint.json
+++ b/tslint.json
@@ -1,34 +1,29 @@
 {
-	"defaultSeverity": "error",
-	"extends": [
-		"tslint:recommended"
-	],
-	"jsRules": {},
-	"rules": {
-		"object-literal-sort-keys": false,
-		"interface-name": false,
-		"no-console": false,
-		"indent": [
-			true,
-			"tabs",
-			2
-		],
-		"no-conditional-assignment": false,
-		"arrow-parens": false,
-		"no-redundant-jsdoc": true,
-		"completed-docs": [
-		  true,
-		  {
-		    "functions": {"visibilities": ["exported"]}
-		  }
-		],
-		"file-name-casing": [true, "camel-case"]
-	},
-	"rulesDirectory": [],
-	"linterOptions": {
-		"exclude": [
-			"src/serviceWorker.ts",
-			"./src/types/tau-prolog/index.d.ts"
-		]
-	}
+  "defaultSeverity": "error",
+  "extends": ["tslint:recommended"],
+  "jsRules": {},
+  "rules": {
+    "object-literal-sort-keys": false,
+    "interface-name": false,
+    "no-console": false,
+    "indent": [true, "tabs", 2],
+    "no-conditional-assignment": false,
+    "arrow-parens": false,
+    "no-redundant-jsdoc": true,
+    "completed-docs": [
+      true,
+      {
+        "functions": { "visibilities": ["exported"] }
+      }
+    ],
+    "file-name-casing": [true, "camel-case"]
+  },
+  "rulesDirectory": [],
+  "linterOptions": {
+    "exclude": [
+      "swipl-wasm/*",
+      "src/serviceWorker.ts",
+      "./src/types/tau-prolog/index.d.ts"
+    ]
+  }
 }


### PR DESCRIPTION
An attempt to make the prolog connection easier to use.

Does not handle multiple results or errors correctly yet.