### PR TITLE
Add a variable that hinders the message from being displayed without …

### DIFF
--- a/src/components/proofEditor/proofEditor.tsx
+++ b/src/components/proofEditor/proofEditor.tsx
@@ -8,7 +8,6 @@ import IssueInformation from "./issueInformation";
 import styles from "./proofEditor.module.scss";
 
 const textboxPlaceHolder = "Gebe hier deinen Beweis ein...";
-let hasStarted = false;
 
 /** The parent component needs to control the proofEditor and have these states */
 export interface IParentState {
@@ -66,7 +65,6 @@ class ProofEditor extends React.Component<IProps, {}> {
 	}
 
 	private readonly checkInput = async (): Promise<void> => {
-		hasStarted = true;
 		let userInput = this.props.userInput;
 		if (this.props.transformUserinputPreCheck) {
 			userInput = this.props.transformUserinputPreCheck(userInput);
@@ -77,7 +75,7 @@ class ProofEditor extends React.Component<IProps, {}> {
 	}
 
 	private renderIssueList(): JSX.Element | JSX.Element[] {
-		if (this.props.issues.length === 0 && hasStarted === true) {
+		if (this.props.issues.length === 0 && this.props.userInput !== "") {
 			return <div
 					className={styles.successMessage}
 				>

--- a/src/components/proofEditor/proofEditor.tsx
+++ b/src/components/proofEditor/proofEditor.tsx
@@ -8,6 +8,7 @@ import IssueInformation from "./issueInformation";
 import styles from "./proofEditor.module.scss";
 
 const textboxPlaceHolder = "Gebe hier deinen Beweis ein...";
+let hasStarted = false;
 
 /** The parent component needs to control the proofEditor and have these states */
 export interface IParentState {
@@ -65,6 +66,7 @@ class ProofEditor extends React.Component<IProps, {}> {
 	}
 
 	private readonly checkInput = async (): Promise<void> => {
+		hasStarted = true;
 		let userInput = this.props.userInput;
 		if (this.props.transformUserinputPreCheck) {
 			userInput = this.props.transformUserinputPreCheck(userInput);
@@ -75,7 +77,7 @@ class ProofEditor extends React.Component<IProps, {}> {
 	}
 
 	private renderIssueList(): JSX.Element | JSX.Element[] {
-		if (this.props.issues.length === 0) {
+		if (this.props.issues.length === 0 && hasStarted === true) {
 			return <div
 					className={styles.successMessage}
 				>


### PR DESCRIPTION
…userinput.

Currently the successmessage gets displayed when going on the webpage immediately, i.e. without the user doing anything. Assuming the user makes a correct proof, this could lead to confusion, since nothing changed at all.

This PR fixes this by introducing a variable `hasStarted` (boolean) to keep track if the "Prüfen"-Button was clicked already or not.